### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0-beta"
 edition = "2021"
 license = "GPL-3.0"
 description = "easy to use crate for using rocm-smi from rust"
+repository = "https://github.com/PTFOPlayer/rocm_lib"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it